### PR TITLE
NoMethodError: undefined method `join' for String

### DIFF
--- a/lib/backgrounder/workers/store_asset.rb
+++ b/lib/backgrounder/workers/store_asset.rb
@@ -6,8 +6,8 @@ module CarrierWave
       def perform
         record = klass.find id
         if record.send :"#{column}_tmp"
-          cache_dir  = record.send(:"#{column}").root + "/" + record.send(:"#{column}").cache_dir
-          cache_path = cache_dir + "/" + record.send(:"#{column}_tmp")
+          cache_dir  = [record.send(:"#{column}").root, record.send(:"#{column}").cache_dir].join("/")
+          cache_path = [cache_dir,record.send(:"#{column}_tmp")].join("/")
         
           record.send :"process_upload=", true
           record.send :"#{column}=", File.open(cache_path)


### PR DESCRIPTION
first of all thanks for your implementation of carrierwave using dj. I've recently found out that for some reason the enqued job was failing after starting the worker by issuing each time a no method error for the cache_dir and cache-path as defined in the store_asset worker. Reason was that from a quick irb prompt I just got:

> > String.join
> > NoMethodError: undefined method `join' for String:Class
> >     from (irb):5

ruby 1.8.7 (2009-06-12 patchlevel 174) [i686-darwin10.0.0]
