### PR TITLE
Set column changed flag before saving

### DIFF
--- a/lib/backgrounder/orm/data_mapper.rb
+++ b/lib/backgrounder/orm/data_mapper.rb
@@ -6,36 +6,43 @@ module CarrierWave
         include CarrierWave::Backgrounder::ORM::Base
 
         def process_in_background(column, worker=::CarrierWave::Workers::ProcessAsset)
-          send :before, :save, :"set_#{column}_processing"
-          send :after,  :save, :"enqueue_#{column}_background_job"
+          before :save, :"set_#{column}_processing"
+          after  :save, :"enqueue_#{column}_background_job"
 
           class_eval  <<-RUBY, __FILE__, __LINE__ + 1
             attr_accessor :process_#{column}_upload
+            attr_reader :#{column}_changed
 
             def set_#{column}_processing
-              unless trigger_#{column}_background_processing?
-                self.#{column}_processing = true if respond_to?(:#{column}_processing) 
-              end
+              @#{column}_changed = attribute_dirty?(:#{column})
+              self.#{column}_processing = true if respond_to?(:#{column}_processing) 
             end
 
             def enqueue_#{column}_background_job
-              unless trigger_#{column}_background_processing?
+              if trigger_#{column}_background_processing?
                 ::Delayed::Job.enqueue #{worker}.new(self.class, id, #{column}.mounted_as) 
+                @#{column}_changed = false
               end
             end
 
             def trigger_#{column}_background_processing?
-              process_#{column}_upload != true && attribute_dirty?(:#{column})
+              process_#{column}_upload != true && #{column}_changed
             end
 
           RUBY
         end
 
         def store_in_background(column, worker=::CarrierWave::Workers::StoreAsset)
-          send :after, :save, :"enqueue_#{column}_background_job"
+          before :save, :"set_#{column}_changed"
+          after :save, :"enqueue_#{column}_background_job"
 
           class_eval  <<-RUBY, __FILE__, __LINE__ + 1
             attr_accessor :process_#{column}_upload
+            attr_reader :#{column}_changed
+
+            def set_#{column}_changed
+              @#{column}_changed = attribute_dirty?(:#{column})
+            end
 
             def write_#{column}_identifier
               super() and return if process_#{column}_upload
@@ -47,13 +54,14 @@ module CarrierWave
             end
 
             def enqueue_#{column}_background_job
-              unless trigger_#{column}_background_storage?
+              if trigger_#{column}_background_storage?
                 ::Delayed::Job.enqueue #{worker}.new(self.class, id, #{column}.mounted_as) 
+                @#{column}_changed = false
               end
             end
 
             def trigger_#{column}_background_storage?
-              process_#{column}_upload != true && attribute_dirty?(:#{column})
+              process_#{column}_upload != true && #{column}_changed
             end
 
           RUBY


### PR DESCRIPTION
Hey - the last pull request I sent you was horribly broken and resulted in a bunch of "NoMethodError `read` for nil class" because it would try to process resources without actual images attached. The reason being that queing the processing would occur after save, thus `attribute_dirty?` would always be false. I also believe this would be a problem with the ActiveRecord version, as `changed?` (I believe - haven't used AR in years) no longer returns true after save.
