### PR TITLE
Avoid jobs failed by ActiveRecord::RecordNotFound

### DIFF
--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -11,14 +11,17 @@ module CarrierWave
 
       def perform
         resource = klass.is_a?(String) ? klass.constantize : klass
-        record = resource.find id
-        record.send(:"process_#{column}_upload=", true)
-        if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
-          record.update_attribute :"#{column}_processing", nil
+        record = resource.find_by_id id
+
+        if record
+          record.send(:"process_#{column}_upload=", true)
+          if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
+            record.update_attribute :"#{column}_processing", nil
+          end
         end
       end
-      
+
     end # ProcessAsset
-    
+
   end # Workers
 end # Backgrounder


### PR DESCRIPTION
Does this make sense for you, to avoid activerecord errors when delete the resource you are going to process before process it?
