### PR TITLE
Ideas and fixes.

### DIFF
--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -106,8 +106,13 @@ module CarrierWave
             end
             
             def write_#{column}_identifier
-              super() and return if process_#{column}_upload
-              self.#{column}_tmp = _mounter(:#{column}).cache_name
+              if remove_#{column}?
+                super
+                self.#{column}_tmp = nil
+              else
+                super and return if process_#{column}_upload
+                self.#{column}_tmp = _mounter(:#{column}).cache_name || self.#{column}_tmp
+              end
             end
 
             def store_#{column}!
@@ -127,7 +132,7 @@ module CarrierWave
             end
 
             def trigger_#{column}_background_storage?
-              process_#{column}_upload != true
+              process_#{column}_upload != true && #{column}_tmp.present? && #{column}_tmp_changed?
             end
 
           RUBY


### PR DESCRIPTION
1. Added `#{column}` accessor for retrieving cached uploader.
2. Carrierwave call's `write_#{column}_identifier` on save to clear column value if column was marked for removal (with `remove_#{column}=` or `remove_#{column}!` methods).
3. Don't clear `#{column}_tmp` if no file was provided (it also fixes issue in mongoid that prevents deletion of embedded document).
4. Check `#{column}_tmp` for presence and changes before enqueue background job.
