### PR TITLE
store_in_background failed because {column}_tmp may set to nil accidentally

### DIFF
--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -98,7 +98,7 @@ module CarrierWave
 
             def write_#{column}_identifier
               super() and return if process_#{column}_upload
-              self.#{column}_tmp = _mounter(:#{column}).cache_name
+              self.#{column}_tmp = _mounter(:#{column}).cache_name if _mounter(:#{column}).cache_name
             end
 
             def store_#{column}!


### PR DESCRIPTION
Using store_in_background:

After uploading to tmp directory and before the worker uploading to aws s3, if the record save again, then the {column}_tmp will set to nil which make the worker fail to upload.

record.avatar = File.open("foobar.png")
record.save # suppose the worker does not process immediately
record.foobar = "foobar" # this may be happened in another request to update the same record.
record.save # this will make avatar_tmp to nil. Suppose the worker now process and will see avatar_tmp is nil, then it do nothing :(
