### PR TITLE
Mongoid 3.0.x Fix

### DIFF
--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -51,13 +51,13 @@ module CarrierWave
 
             def enqueue_#{column}_background_job
               if defined? ::GirlFriday
-                CARRIERWAVE_QUEUE << { :worker => #{worker}.new(self.class.name, id, #{column}.mounted_as) }
+                CARRIERWAVE_QUEUE << { :worker => #{worker}.new(self.class.name, id.to_s, #{column}.mounted_as) }
               elsif defined? ::Delayed::Job
-                ::Delayed::Job.enqueue #{worker}.new(self.class.name, id, #{column}.mounted_as)
+                ::Delayed::Job.enqueue #{worker}.new(self.class.name, id.to_s, #{column}.mounted_as)
               elsif defined? ::Resque
-                ::Resque.enqueue #{worker}, self.class.name, id, #{column}.mounted_as
+                ::Resque.enqueue #{worker}, self.class.name, id.to_s, #{column}.mounted_as
               elsif defined? ::Qu
-                ::Qu.enqueue #{worker}, self.class.name, id, #{column}.mounted_as
+                ::Qu.enqueue #{worker}, self.class.name, id.to_s, #{column}.mounted_as
               end
             end
 


### PR DESCRIPTION
When tasks were being placed in the queue system, the "id" property of the model was sending an ObjectId object to the queue system instead of a simple string version of the model id.  I changed the code to call "to_s" on the ID property and ensure that only simple values are being sent to the queue.

Tested with Mongoid 3.0.1 & Resque 1.21.0
