### PR TITLE
To enqueue, also check the existence of remote_#{column}_url

### DIFF
--- a/lib/backgrounder/orm/activerecord.rb
+++ b/lib/backgrounder/orm/activerecord.rb
@@ -13,7 +13,7 @@ module CarrierWave
 
           class_eval  <<-RUBY, __FILE__, __LINE__ + 1
             def trigger_#{column}_background_processing?
-              super && (#{column}_changed? || remote_#{column}_url.empty? == false)
+              super && (#{column}_changed? || remote_#{column}_url.present?)
             end
           RUBY
         end
@@ -23,7 +23,7 @@ module CarrierWave
 
           class_eval  <<-RUBY, __FILE__, __LINE__ + 1
             def trigger_#{column}_background_storage?
-              super && (#{column}_changed? || remote_#{column}_url.empty? == false)
+              super && (#{column}_changed? || remote_#{column}_url.present?)
             end
           RUBY
         end

--- a/lib/backgrounder/orm/mongoid.rb
+++ b/lib/backgrounder/orm/mongoid.rb
@@ -10,7 +10,7 @@ module CarrierWave
 
           class_eval  <<-RUBY, __FILE__, __LINE__ + 1
             def trigger_#{column}_background_processing?
-              super && (#{column}_changed? || remote_#{column}_url.empty? == false)
+              super && (#{column}_changed? || remote_#{column}_url.present?)
             end
           RUBY
         end
@@ -20,7 +20,7 @@ module CarrierWave
 
           class_eval  <<-RUBY, __FILE__, __LINE__ + 1
             def trigger_#{column}_background_storage?
-              super && (#{column}_changed? || remote_#{column}_url.empty? == false)
+              super && (#{column}_changed? || remote_#{column}_url.present?)
             end
           RUBY
         end


### PR DESCRIPTION
When creating the image from a remote source via remote_#{column}_url, the job fails to enqueue
because #{column}_changed? is always false. This adds an extra check on the remote_#{column}_url 
and if it's not empty, than enqueue the job. 

I'm not sure whether this is the correct fix for this. I added these for active record and mongoid, but not for data mapper since I couldn't test it. 
