### PR TITLE
Patch up DataMapper adapter to work with backend selection logic

### DIFF
--- a/lib/backgrounder/orm/data_mapper.rb
+++ b/lib/backgrounder/orm/data_mapper.rb
@@ -20,7 +20,7 @@ module CarrierWave
 
             def enqueue_#{column}_background_job
               if trigger_#{column}_background_processing?
-                ::Delayed::Job.enqueue #{worker}.new(self.class, id, #{column}.mounted_as) 
+                CarrierWave::Backgrounder.enqueue_for_backend(#{worker}, self.class.name, id, #{column}.mounted_as)
                 @#{column}_changed = false
               end
             end
@@ -55,7 +55,7 @@ module CarrierWave
 
             def enqueue_#{column}_background_job
               if trigger_#{column}_background_storage?
-                ::Delayed::Job.enqueue #{worker}.new(self.class, id, #{column}.mounted_as) 
+                CarrierWave::Backgrounder.enqueue_for_backend(#{worker}, self.class.name, id, #{column}.mounted_as)
                 @#{column}_changed = false
               end
             end


### PR DESCRIPTION
Looks like the code in there was entirely different and tied to Delayed::Job, so I missed it the first time around.
