### PR TITLE
Fix ORM namespacing.

### DIFF
--- a/lib/carrierwave_backgrounder.rb
+++ b/lib/carrierwave_backgrounder.rb
@@ -84,7 +84,7 @@ if defined?(Rails)
         initializer "carrierwave_backgrounder.active_record" do
           ActiveSupport.on_load :active_record do
             require 'backgrounder/orm/activemodel'
-            ActiveRecord::Base.extend CarrierWave::Backgrounder::ORM::ActiveModel
+            ::ActiveRecord::Base.extend CarrierWave::Backgrounder::ORM::ActiveModel
           end
         end
 
@@ -95,7 +95,7 @@ if defined?(Rails)
         initializer "carrierwave_backgrounder.mongoid" do
           if defined?(Mongoid)
             require 'backgrounder/orm/activemodel'
-            Mongoid::Document::ClassMethods.send(:include, ::CarrierWave::Backgrounder::ORM::ActiveModel)
+            ::Mongoid::Document::ClassMethods.send(:include, ::CarrierWave::Backgrounder::ORM::ActiveModel)
           end
         end
 


### PR DESCRIPTION
Hi, just a short fix for namespacing issue. Neither ActiveRecord nor Mongoid is local to CarrierWave namespace, so start lookup from global namespace. This fixes #78.
