### PR TITLE
Sidekiq queue name

### DIFF
--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -7,6 +7,7 @@ module CarrierWave
 
       if defined?(::Sidekiq)
         include ::Sidekiq::Worker
+
         sidekiq_options :queue => @queue
       end
 

--- a/lib/backgrounder/workers/store_asset.rb
+++ b/lib/backgrounder/workers/store_asset.rb
@@ -7,6 +7,7 @@ module CarrierWave
 
       if defined?(::Sidekiq)
         include ::Sidekiq::Worker
+
         sidekiq_options :queue => @queue
       end
 

--- a/spec/support/backend_constants.rb
+++ b/spec/support/backend_constants.rb
@@ -16,6 +16,14 @@ end
 
 module Sidekiq
   module Worker
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def sidekiq_options(opts = {})
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Hi, at the moment both process_asset and store_asset jobs get queued to default queue in sidekig because it does not use @queue for identification (https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/worker.rb). This changes makes use of sidekiq_options so jobs get into properly named queues.
