### PR TITLE
Use after_commit if it is available to support reactive workers.

### DIFF
--- a/lib/backgrounder/orm/activemodel.rb
+++ b/lib/backgrounder/orm/activemodel.rb
@@ -14,7 +14,7 @@ module CarrierWave
           include mod
           mod.module_eval  <<-RUBY, __FILE__, __LINE__ + 1
             def trigger_#{column}_background_processing?
-              super && (#{column}_changed? || remote_#{column}_url.present?)
+              super && (#{column}_changed? || previous_changes.has_key?(:#{column}) || remote_#{column}_url.present?)
             end
           RUBY
         end
@@ -26,7 +26,7 @@ module CarrierWave
           include mod
           mod.module_eval  <<-RUBY, __FILE__, __LINE__ + 1
             def trigger_#{column}_background_storage?
-              super && (#{column}_changed? || remote_#{column}_url.present?)
+              super && (#{column}_changed? || previous_changes.has_key?(:#{column}) || remote_#{column}_url.present?)
             end
           RUBY
         end

--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -40,7 +40,11 @@ module CarrierWave
         #
         def process_in_background(column, worker=::CarrierWave::Workers::ProcessAsset)
           send :before_save, :"set_#{column}_processing", :if => :"trigger_#{column}_background_processing?"
-          send :after_commit,  :"enqueue_#{column}_background_job", :if => :"trigger_#{column}_background_processing?"
+          if self.respond_to?(:after_commit)
+            send :after_commit,  :"enqueue_#{column}_background_job", :if => :"trigger_#{column}_background_processing?"
+          else
+            send :after_save,  :"enqueue_#{column}_background_job", :if => :"trigger_#{column}_background_processing?"
+          end
           send :attr_accessor, :"process_#{column}_upload"
 
           mod = Module.new
@@ -86,7 +90,11 @@ module CarrierWave
         #   end
         #
         def store_in_background(column, worker=::CarrierWave::Workers::StoreAsset)
-          send :after_commit, :"enqueue_#{column}_background_job", :if => :"trigger_#{column}_background_storage?"
+          if self.respond_to?(:after_commit)
+            send :after_commit, :"enqueue_#{column}_background_job", :if => :"trigger_#{column}_background_storage?"
+          else
+            send :after_save, :"enqueue_#{column}_background_job", :if => :"trigger_#{column}_background_storage?"
+          end
           send :attr_accessor, :"process_#{column}_upload"
 
           mod = Module.new

--- a/spec/backgrounder/orm/activemodel_spec.rb
+++ b/spec/backgrounder/orm/activemodel_spec.rb
@@ -9,6 +9,7 @@ describe CarrierWave::Backgrounder::ORM::ActiveModel do
       def self.after_commit(method, opts); nil; end
       def avatar_changed?; nil;  end
       def remote_avatar_url; OpenStruct.new(:present? => true); end
+      def previous_changes; {}; end
     end
 
     @mock_class.extend CarrierWave::Backgrounder::ORM::ActiveModel


### PR DESCRIPTION
Hi,

this fixes after_commit support. The callback is specific to ActiveRecord therefore I added a check to see if it is available. Current implementation essentially breaks Mongoid compatibility.

Moreover, #<column>_changed? will always respond with false in after_commit block, because changes hash is already reset. So no background processing will be even triggered. To properly support after_commit we need to check previous_changes hash instead. There is a pretty good explanation here: http://logicalfriday.com/2012/08/21/rails-callbacks-workers-and-the-race-you-never-expected-to-lose/.

Cheers
