### PR TITLE
[RFC] Allow to configure backend by passing options

### DIFF
--- a/lib/carrierwave_backgrounder.rb
+++ b/lib/carrierwave_backgrounder.rb
@@ -8,8 +8,9 @@ module CarrierWave
 
     class << self
       def backend=(value)
-        @backend = value
-        self.configure_backend
+        @backend, options = value
+        options ||= {}
+        self.configure_backend(options)
       end
 
       def backend
@@ -40,10 +41,11 @@ module CarrierWave
         end
       end
 
-      def configure_backend
+      def configure_backend(options)
         if backend == :girl_friday
           require 'girl_friday'
-          @girl_friday_queue = GirlFriday::WorkQueue.new(:carrierwave) do |msg|
+          queue_name = options.delete(:queue) || :carrierwave
+          @girl_friday_queue = GirlFriday::WorkQueue.new(queue_name, options) do |msg|
             worker = msg[:worker]
             worker.perform
           end


### PR DESCRIPTION
This allows to pass options to the queue backend, currently only useful with GirlFriday. I needed this to be able to modify the number of workers and use redis as persistence store with gf.

Example:

``` ruby
CarrierWave::Backgrounder.configure do |c|
    c.backend = :girl_friday, { size: 3 }
end
```

While this works, I'm not really happy with abusing a setter method to pass in an option hash. However using a seperate setter would not work without further changes, because options would net to be set before setting the backend and it's not a good idea to depend on the order of these settings in the configuration block.

Another option at least for GirlFriday would be to pass in an instance of a GrilFriday Queue, so we could set it up in an initializer and then pass it to cw backgrounder.

@lardawge: What's your thoughts on this?
