### PR TITLE
Add support for passing options to girl_friday

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ CarrierWave::Backgrounder.configure do |c|
 end
 ```
 
+You can also pass additional configuration options to girl_friday
+
+```ruby
+CarrierWave::Backgrounder.configure do |c|
+  c.backend :girl_friday, queue: :awesome_queue, size: 3, store: GirlFriday::Store::Redis
+end
+```
+
 In your CarrierWave uploader file:
 
 ```ruby

--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -32,7 +32,7 @@ module Support
       def enqueue_for_backend(worker, class_name, subject_id, mounted_as)
         case backend
         when :girl_friday
-          @girl_friday_queue ||= GirlFriday::WorkQueue.new(queue_options[:queue] || :carrierwave) do |msg|
+          @girl_friday_queue ||= GirlFriday::WorkQueue.new(queue_options.delete(:queue) || :carrierwave, queue_options) do |msg|
             worker = msg[:worker]
             worker.perform
           end


### PR DESCRIPTION
This adds support for passing options to the GirlFriday::WorkQueue. This is needed to set the number of worker threads or configure a redis store for persistence.

A full example with redis could look like:

``` ruby
CarrierWave::Backgrounder.configure do |c|
  c.backend :girl_friday, queue: :image_processing, size: 10, store: GirlFriday::Store::Redis
end
```
