### PR TITLE
resupport sidekiq worker

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -46,9 +46,8 @@ module Support
           worker.instance_variable_set('@queue', queue_options[:queue] || :carrierwave)
           ::Qu.enqueue worker, class_name, subject_id, mounted_as
         when :sidekiq
-          worker.extend ::Sidekiq::Worker
-          worker.sidekiq_options queue_options[:queue] || :carrierwave
-          ::Sidekiq::Client.enqueue worker, class_name, subject_id, mounted_as
+          ::CarrierWave::Workers::SidekiqWorker.sidekiq_options(:queue => queue_options[:queue] || :carrierwave)
+          ::Sidekiq::Client.enqueue ::CarrierWave::Workers::SidekiqWorker, worker.to_s, class_name, subject_id, mounted_as
         when :qc
           ::QC.enqueue "#{worker.name}.perform", class_name, subject_id, mounted_as.to_s
         when :immediate

--- a/lib/backgrounder/workers.rb
+++ b/lib/backgrounder/workers.rb
@@ -1,2 +1,4 @@
 require 'backgrounder/workers/process_asset'
 require 'backgrounder/workers/store_asset'
+
+require 'backgrounder/workers/sidekiq_worker'

--- a/lib/backgrounder/workers/sidekiq_worker.rb
+++ b/lib/backgrounder/workers/sidekiq_worker.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+begin
+  require "sidekiq"
+  
+  class CarrierWave::Workers::SidekiqWorker
+    include ::Sidekiq::Worker
+    
+    def perform(*args)
+      worker = args.shift
+      worker.constantize.perform(*args)
+    end
+  end
+rescue LoadError => e
+  # missing skip
+end
+


### PR DESCRIPTION
sidekiq worker must static include ::Sidekiq::Worker.

because, on sidekiq process, it running pseudo code like:

``` ruby
w = worker_class.new
w.jid = "ooxx"
w.perform(*args)
```

if dynamic include `::Sidekiq::Worker` on carrierwave_backgrounder.
sidekiq will raise `NoMethodError` for `jid=`
