### PR TITLE
Fix determine_backend and Sidekiq integration

### DIFF
--- a/lib/carrierwave_backgrounder.rb
+++ b/lib/carrierwave_backgrounder.rb
@@ -8,7 +8,7 @@ module CarrierWave
     include Support::Backends
 
     class UnsupportedBackendError < StandardError ; end
-    class ToManyBackendsAvailableError < StandardError ; end
+    class TooManyBackendsAvailableError < StandardError ; end
 
     def self.configure
       yield self

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -33,10 +33,6 @@ describe Support::Backends do
     it 'detects QC' do
       expect(mock_module.available_backends).to include(:qc)
     end
-
-    it 'detects Immediate' do
-      expect(mock_module.available_backends).to include(:immediate)
-    end
   end
 
   describe 'setting backend' do
@@ -77,7 +73,7 @@ describe Support::Backends do
       mock_module.stubs(:available_backends).returns([:qu, :resque])
       expect {
        mock_module.backend
-      }.to raise_error(CarrierWave::Backgrounder::ToManyBackendsAvailableError)
+      }.to raise_error(CarrierWave::Backgrounder::TooManyBackendsAvailableError)
     end
 
     it 'does not clobber a manually set backend' do
@@ -132,22 +128,23 @@ describe Support::Backends do
     end
 
     context 'sidekiq' do
-      let(:args) { [MockWorker, 'FakeClass', 1, :image] }
-      before do
-        Sidekiq::Client.expects(:enqueue).with(*args)
-      end
+      let(:args) { ['FakeClass', 1, :image] }
 
-      it 'sets sidekiq_options to empty hash and calls enqueue with passed args' do
-        MockWorker.expects(:sidekiq_options).with({})
+      it 'invokes client_push on the class with passed args' do
+        MockSidekiqWorker.expects(:client_push).with({ 'class' => MockSidekiqWorker, 'args' => args })
         mock_module.backend :sidekiq
-        mock_module.enqueue_for_backend(*args)
+        mock_module.enqueue_for_backend(MockSidekiqWorker, *args)
       end
 
-      it 'sets sidekiq_options to the options passed to backend' do
+      it 'invokes client_push and includes the options passed to backend' do
+        MockSidekiqWorker.expects(:client_push).with({ 'class' => MockSidekiqWorker, 
+                                                       'retry' => false,
+                                                       'timeout' => 60,
+                                                       'queue' => :awesome_queue,
+                                                       'args' => args })
         options = {:retry => false, :timeout => 60, :queue => :awesome_queue}
-        MockWorker.expects(:sidekiq_options).with(options)
         mock_module.backend :sidekiq, options
-        mock_module.enqueue_for_backend(*args)
+        mock_module.enqueue_for_backend(MockSidekiqWorker, *args)
       end
     end
 

--- a/spec/support/backend_constants.rb
+++ b/spec/support/backend_constants.rb
@@ -28,6 +28,9 @@ module Sidekiq
     module ClassMethods
       def sidekiq_options(opts = {})
       end
+
+      def client_push(item)
+      end
     end
   end
 end

--- a/spec/support/mock_worker.rb
+++ b/spec/support/mock_worker.rb
@@ -11,3 +11,7 @@ class MockWorker < Struct.new(:klass, :id, :column)
     self.klass, self.id, self.column = klass, id, column
   end
 end
+
+class MockSidekiqWorker < MockWorker
+  include Sidekiq::Worker
+end


### PR DESCRIPTION
This pull request makes a few changes:

i) Removes :immediate from the available_backends hash - The presence of this value ensured that, in a real world situaton where a task processing library is included, the determine_backend method always throws an exception because the size of the available_backends hash was always at least 2.  So backend processing simply doesn't work in real life situations.

ii) Changes the Sidekiq integration - The approach used to integrate with Sidekiq in the enqueue_sidekiq method has a number of drawbacks.  Most significantly, it breaks the 'sidekiq/testing' integration - jobs enqueued by carrierwave_backgrounder don't go to the test queue.  Presumably this approach was taken to set the Sidekiq options on a per-instance basis.  But the same goal can be accomplished by using client_push, which is compatible with 'sidekiq/testing'.

iii) Corrects a spelling error - The name of the ::CarrierWave::Backgrounder::TooManyBackendsAvailableError class and its corresponding message were misspelled - 'To' was being used instead of 'Too'

The carrierwave_backgrounder tests are passing, as are our carrrierwave_backgrounder-related application tests (which were failing with the latest carrierwave_backgrounder gem)
