### PR TITLE
Rename exception and update message to fix typo

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -40,8 +40,8 @@ module Support
           warn 'WARNING: No available queue backends found for CarrierWave::Backgrounder. Using the :immediate.'
           :immediate
         elsif available_backends.size > 1
-          raise ::CarrierWave::Backgrounder::ToManyBackendsAvailableError,
-            "You have to many backends available: #{available_backends.inspect}. Please specify which one to use in configuration block"
+          raise ::CarrierWave::Backgrounder::TooManyBackendsAvailableError,
+            "You have too many backends available: #{available_backends.inspect}. Please specify which one to use in configuration block"
         else
           available_backends.first
         end

--- a/lib/carrierwave_backgrounder.rb
+++ b/lib/carrierwave_backgrounder.rb
@@ -8,7 +8,7 @@ module CarrierWave
     include Support::Backends
 
     class UnsupportedBackendError < StandardError ; end
-    class ToManyBackendsAvailableError < StandardError ; end
+    class TooManyBackendsAvailableError < StandardError ; end
 
     def self.configure
       yield self

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -77,7 +77,7 @@ describe Support::Backends do
       mock_module.stubs(:available_backends).returns([:qu, :resque])
       expect {
        mock_module.backend
-      }.to raise_error(CarrierWave::Backgrounder::ToManyBackendsAvailableError)
+      }.to raise_error(CarrierWave::Backgrounder::TooManyBackendsAvailableError)
     end
 
     it 'does not clobber a manually set backend' do


### PR DESCRIPTION
Fixes the typo in CarrierWave::Backgrounder::ToManyBackendsAvailableError 's name and the corresponding error message.
