### PR TITLE
Fix determine_backend behavior so that it doesn't throw an exception

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -25,7 +25,7 @@ module Support
           backends << :qu          if defined? ::Qu
           backends << :sidekiq     if defined? ::Sidekiq
           backends << :qc          if defined? ::QC
-          backends << :immediate
+          backends
         end
       end
 

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -33,10 +33,6 @@ describe Support::Backends do
     it 'detects QC' do
       expect(mock_module.available_backends).to include(:qc)
     end
-
-    it 'detects Immediate' do
-      expect(mock_module.available_backends).to include(:immediate)
-    end
   end
 
   describe 'setting backend' do


### PR DESCRIPTION
Removed the :immediate symbol from the available_backends hash, so that in real world cases (where a task processing library is included) the determine_backend method will use the included library.
