### PR TITLE
Change the Sidekiq integration to use client_push

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -57,8 +57,12 @@ module Support
       end
 
       def enqueue_sidekiq(worker, *args)
-        worker.sidekiq_options queue_options
-        ::Sidekiq::Client.enqueue worker, *args
+        sidekiq_client_args = { 'class' => worker, 'args' => args }
+        sidekiq_client_args['queue'] = queue_options[:queue] unless queue_options[:queue].nil?
+        sidekiq_client_args['retry'] = queue_options[:retry] unless queue_options[:retry].nil?
+        sidekiq_client_args['timeout'] = queue_options[:timeout] unless queue_options[:timeout].nil?
+        sidekiq_client_args['backtrace'] = queue_options[:backtrace] unless queue_options[:backtrace].nil?
+        worker.client_push(sidekiq_client_args)
       end
 
       def enqueue_girl_friday(worker, *args)

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -132,22 +132,23 @@ describe Support::Backends do
     end
 
     context 'sidekiq' do
-      let(:args) { [MockWorker, 'FakeClass', 1, :image] }
-      before do
-        Sidekiq::Client.expects(:enqueue).with(*args)
-      end
+      let(:args) { ['FakeClass', 1, :image] }
 
-      it 'sets sidekiq_options to empty hash and calls enqueue with passed args' do
-        MockWorker.expects(:sidekiq_options).with({})
+      it 'invokes client_push on the class with passed args' do
+        MockSidekiqWorker.expects(:client_push).with({ 'class' => MockSidekiqWorker, 'args' => args })
         mock_module.backend :sidekiq
-        mock_module.enqueue_for_backend(*args)
+        mock_module.enqueue_for_backend(MockSidekiqWorker, *args)
       end
 
-      it 'sets sidekiq_options to the options passed to backend' do
+      it 'invokes client_push and includes the options passed to backend' do
+        MockSidekiqWorker.expects(:client_push).with({ 'class' => MockSidekiqWorker, 
+                                                       'retry' => false,
+                                                       'timeout' => 60,
+                                                       'queue' => :awesome_queue,
+                                                       'args' => args })
         options = {:retry => false, :timeout => 60, :queue => :awesome_queue}
-        MockWorker.expects(:sidekiq_options).with(options)
         mock_module.backend :sidekiq, options
-        mock_module.enqueue_for_backend(*args)
+        mock_module.enqueue_for_backend(MockSidekiqWorker, *args)
       end
     end
 

--- a/spec/support/backend_constants.rb
+++ b/spec/support/backend_constants.rb
@@ -28,6 +28,9 @@ module Sidekiq
     module ClassMethods
       def sidekiq_options(opts = {})
       end
+
+      def client_push(item)
+      end
     end
   end
 end

--- a/spec/support/mock_worker.rb
+++ b/spec/support/mock_worker.rb
@@ -11,3 +11,7 @@ class MockWorker < Struct.new(:klass, :id, :column)
     self.klass, self.id, self.column = klass, id, column
   end
 end
+
+class MockSidekiqWorker < MockWorker
+  include Sidekiq::Worker
+end


### PR DESCRIPTION
Instead of calling Sidekiq::Client.enqueue, use the worker's client_push method instead.  This had the benefit of being compatible with Sidekiq's testing shim, as well as being more decoupled from the details of Sidekiq's implementation.
