### PR TITLE
Set default queue_options with backend=

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -6,7 +6,6 @@ module Support
     end
 
     module ClassMethods
-      attr_writer :backend
       attr_reader :queue_options
 
       def backend(queue_name=nil, args={})
@@ -14,7 +13,12 @@ module Support
         @queue_options = args
         @backend = queue_name
       end
-
+      
+      def backend=(queue_name)
+        @queue_options = {}
+        @backend = queue_name
+      end
+      
       def enqueue_for_backend(worker, class_name, subject_id, mounted_as)
         self.send :"enqueue_#{backend}", worker, class_name, subject_id, mounted_as
       end

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -13,6 +13,7 @@ describe Support::Backends do
     it 'using #backend=' do
       mock_module.backend = :delayed_job
       expect(mock_module.backend).to eql(:delayed_job)
+      expect(mock_module.queue_options).to_not be_nil
     end
 
     it 'using #backend' do


### PR DESCRIPTION
Backends::backend= was broken because @queue_options wasn't being set.

This pull request sets a default @queue_options when calling that method.
(Other way to fix this is just removing backend = and breaking apps when they get loaded :)
