### PR TITLE
Noop in Rails test env

### DIFF
--- a/lib/backgrounder/orm/activemodel_test.rb
+++ b/lib/backgrounder/orm/activemodel_test.rb
@@ -1,0 +1,4 @@
+module ::CarrierWave::Backgrounder::ORM::ActiveModel
+  def process_in_background(*args); end
+  def store_in_background(*args); end
+end

--- a/lib/backgrounder/orm/data_mapper_test.rb
+++ b/lib/backgrounder/orm/data_mapper_test.rb
@@ -1,0 +1,4 @@
+module ::CarrierWave::Backgrounder::ORM::DataMapper
+  def process_in_background(*args); end
+  def store_in_background(*args); end
+end

--- a/lib/carrierwave_backgrounder.rb
+++ b/lib/carrierwave_backgrounder.rb
@@ -35,17 +35,22 @@ if defined?(Rails)
         initializer "carrierwave_backgrounder.active_record" do
           ActiveSupport.on_load :active_record do
             require 'backgrounder/orm/activemodel'
+            require 'backgrounder/orm/activemodel_test' if Rails.env.test?
             ::ActiveRecord::Base.extend CarrierWave::Backgrounder::ORM::ActiveModel
           end
         end
 
         initializer "carrierwave_backgrounder.data_mapper", :before =>"data_mapper.add_to_prepare" do
-          require 'backgrounder/orm/data_mapper' if defined?(DataMapper)
+          if defined?(DataMapper)
+            require 'backgrounder/orm/data_mapper'
+            require 'backgrounder/orm/data_mapper_test' if Rails.env.test?
+          end
         end
 
         initializer "carrierwave_backgrounder.mongoid" do
           if defined?(Mongoid)
             require 'backgrounder/orm/activemodel'
+            require 'backgrounder/orm/activemodel_test' if Rails.env.test?
             ::Mongoid::Document::ClassMethods.send(:include, ::CarrierWave::Backgrounder::ORM::ActiveModel)
           end
         end


### PR DESCRIPTION
If we just kinda ignore the method call then processing will happen when
wanted[*] and it won't the rest of the time.

These were tested against an actual app. Pre-change all uploader-related
specs failed. Post-change they all passed.

[*]

``` ruby
AvatarUploader.enable_processing = true
```
