### PR TITLE
SuckerPunch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 I like CarrierWave. That being said, I don't like tying up app instances waiting for images to process.
 
 This gem addresses that by offloading processing or storage/processing to a background task.
-We currently support Delayed Job, Resque, Sidekiq, Girl Friday, Qu, and Queue Classic.
+We currently support Delayed Job, Resque, Sidekiq, SuckerPunch, Girl Friday, Qu, and Queue Classic.
 
 ## Background options
 
@@ -54,6 +54,19 @@ CarrierWave::Backgrounder.configure do |c|
   c.backend :girl_friday, queue: :awesome_queue, size: 3, store: GirlFriday::Store::Redis
 end
 ```
+
+For SuckerPunch, you have to configure your queue with a specific worker.
+
+```ruby
+SuckerPunch.config do
+  queue name: :carrierwave, worker: CarrierWave::Workers::StoreAsset, size: 2
+end
+
+CarrierWave::Backgrounder.configure do |c|
+  c.backend :sucker_punch, queue: :carrierwave
+end
+```
+
 
 In your CarrierWave uploader file:
 

--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -46,6 +46,11 @@ module Support
         @girl_friday_queue << { :worker => worker.new(*args) }
       end
 
+      def enqueue_sucker_punch(worker, *args)
+        @sucker_punch_queue ||= SuckerPunch::Queue[queue_options.delete(:queue) || :carrierwave]
+        @sucker_punch_queue.async.perform(*args)
+      end
+
       def enqueue_qu(worker, *args)
         worker.instance_variable_set('@queue', queue_options[:queue] || :carrierwave)
         ::Qu.enqueue worker, *args

--- a/lib/carrierwave_backgrounder.rb
+++ b/lib/carrierwave_backgrounder.rb
@@ -12,7 +12,8 @@ module CarrierWave
 
     def self.configure
       yield self
-      if @backend == :sidekiq
+      case @backend
+      when :sidekiq
         ::CarrierWave::Workers::ProcessAsset.class_eval do
           require 'sidekiq'
           include ::Sidekiq::Worker
@@ -20,6 +21,15 @@ module CarrierWave
         ::CarrierWave::Workers::StoreAsset.class_eval do
           require 'sidekiq'
           include ::Sidekiq::Worker
+        end
+      when :sucker_punch
+        ::CarrierWave::Workers::ProcessAsset.class_eval do
+          require 'sucker_punch'
+          include ::SuckerPunch::Worker
+        end
+        ::CarrierWave::Workers::StoreAsset.class_eval do
+          require 'sucker_punch'
+          include ::SuckerPunch::Worker
         end
       end
     end


### PR DESCRIPTION
GirlFriday author suggests to use SuckerPunch instead.

Here is a initial support. Drawback: the queue uses just one worker type, as per SuckerPunch configuration.
