### PR TITLE
Unsaved records queueing jobs

### DIFF
--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -100,7 +100,7 @@ module CarrierWave
             def #{column}_updated?; true; end
 
             def enqueue_#{column}_background_job?
-              !remove_#{column}? && !process_#{column}_upload && #{column}_updated?
+              !remove_#{column}? && !process_#{column}_upload && #{column}_updated? && !new_record?
             end
 
             def enqueue_#{column}_background_job


### PR DESCRIPTION
`after_commit` is fired even if the record is not saved, so activerecord is currently queueing a job when validation fails.

This commit fixes it for AR, but I don't know if the `new_record?` method exists in data mapper, so I cannot promise that it will not break DM support.
