### PR TITLE
Fail silently when record can't be found in workers.

### DIFF
--- a/lib/backgrounder/railtie.rb
+++ b/lib/backgrounder/railtie.rb
@@ -14,7 +14,7 @@ module CarrierWave
       end
 
       initializer "carrierwave_backgrounder.mongoid" do
-        if defined?(Mongoid)
+        if defined?(::Mongoid)
           require 'backgrounder/orm/activemodel'
           ::Mongoid::Document::ClassMethods.send(:include, ::CarrierWave::Backgrounder::ORM::ActiveModel)
         end

--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -9,7 +9,16 @@ module CarrierWave
 
       def perform(*args)
         set_args(*args) if args.present?
-        record = constantized_resource.find id
+
+        errors = []
+        errors << ::ActiveRecord::RecordNotFound      if defined?(::ActiveRecord)
+        errors << ::Mongoid::Errors::DocumentNotFound if defined?(::Mongoid)
+
+        record = begin
+          constantized_resource.find(id)
+        rescue *errors
+          nil
+        end
 
         if record
           record.send(:"process_#{column}_upload=", true)


### PR DESCRIPTION
ActiveRecord and Mongoid raise `ActiveRecord::RecordNotFound` and `Mongoid::Errors::DocumentNotFound` respectively when `#find` can't find a record, in which case we just want to fail silently instead of crash the worker.
