### PR TITLE
Use find_by_id to not raise exception

### DIFF
--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -10,7 +10,18 @@ module CarrierWave
       def perform(*args)
         set_args(*args) if args.present?
 
-        record = constantized_resource.find_by_id(id)
+        if defined?(::Mongoid)
+          errors = []
+          errors << ::Mongoid::Errors::DocumentNotFound if defined?(::Mongoid)
+
+          record = begin
+            constantized_resource.find(id)
+          rescue *errors
+            nil
+          end
+        else
+          record = constantized_resource.find_by_id(id)
+        end
 
         if record
           record.send(:"process_#{column}_upload=", true)


### PR DESCRIPTION
Use find_by_id to not raise exception when record not found, for example when deleting record.

The previous way was still raising exceptions when using delayed_job for me...
