### PR TITLE
#123 Added log entry when object cannot be found by worker.

### DIFF
--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -17,6 +17,7 @@ module CarrierWave
         record = begin
           constantized_resource.find(id)
         rescue *errors
+          Rails.logger.warn "#{self} could not find #{constantized_resource} instance with id: #{id}"
           nil
         end
 


### PR DESCRIPTION
Instead of failing silently when record cannot be found a warn entry will be added to Rails default logger.
