### PR TITLE
Added #{column}_processing functionality to the store worker also.

### DIFF
--- a/lib/backgrounder/orm/activemodel.rb
+++ b/lib/backgrounder/orm/activemodel.rb
@@ -14,6 +14,7 @@ module CarrierWave
         end
 
         def store_in_background(column, worker=::CarrierWave::Workers::StoreAsset)
+          before_save :"set_#{column}_processing", :if => :"enqueue_#{column}_background_job?"
           send _supported_am_after_callback, :"enqueue_#{column}_background_job", :if => :"enqueue_#{column}_background_job?"
           super
         end

--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -44,9 +44,7 @@ module CarrierWave
           mod = Module.new
           include mod
           mod.class_eval  <<-RUBY, __FILE__, __LINE__ + 1
-            def set_#{column}_processing
-              self.#{column}_processing = true if respond_to?(:#{column}_processing)
-            end
+            
           RUBY
 
           _define_shared_backgrounder_methods(mod, column, worker)
@@ -88,6 +86,7 @@ module CarrierWave
             def store_#{column}!
               super if process_#{column}_upload
             end
+
           RUBY
 
           _define_shared_backgrounder_methods(mod, column, worker)
@@ -98,6 +97,10 @@ module CarrierWave
         def _define_shared_backgrounder_methods(mod, column, worker)
           mod.class_eval  <<-RUBY, __FILE__, __LINE__ + 1
             def #{column}_updated?; true; end
+
+            def set_#{column}_processing
+              self.#{column}_processing = true if respond_to?(:#{column}_processing)
+            end
 
             def enqueue_#{column}_background_job?
               !remove_#{column}? && !process_#{column}_upload && #{column}_updated?

--- a/lib/backgrounder/workers/store_asset.rb
+++ b/lib/backgrounder/workers/store_asset.rb
@@ -26,6 +26,7 @@ module CarrierWave
           store_directories(record)
           record.send :"process_#{column}_upload=", true
           record.send :"#{column}_tmp=", nil
+          record.send :"#{column}_processing=", nil if record.respond_to?(:"#{column}_processing")
           File.open(cache_path) { |f| record.send :"#{column}=", f }
           if record.save!
             FileUtils.rm_r(tmp_directory, :force => true)


### PR DESCRIPTION
This commit adds the functionality of #{column}_processing to the store worker also, not just the processing worker. 

I ended up needing this for a project where I am dynamically resizing an image based on the model attributes. If someone ended up submitting two changes, one right after the other, to the images or the attributes it worked off of, a race condition would issue, where one image ended uploaded with the others crop. The only way to stop this was to check for #{column}_processing before save.

I would have liked to have checked for store also, but that happens after save so adding a flag in for that was not really possible. Also store didn't matter because the conditional processing had already been done. So worst case you end up with the 'wrong' one uploaded, but with the correct corresponding crop.
