### PR TITLE
Save a changed filename

### DIFF
--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -9,8 +9,14 @@ module CarrierWave
 
         if record
           record.send(:"process_#{column}_upload=", true)
-          if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
+          uploader = record.send(:"#{column}")
+          if uploader.recreate_versions! && record.respond_to?(:"#{column}_processing")
             record.update_attribute :"#{column}_processing", nil
+          end
+
+          store_filename = record[:"#{column}"]
+          if store_filename != uploader.filename
+            record.save!
           end
         end
       end


### PR DESCRIPTION
When generating unique filenames for every file, the record needs to be saved after `recreate_versions!`. This PR saves the record, when the filename stored in the db is different then in the current uploader (filename changed).

The carrierwave documentation has an entry about this here: https://github.com/carrierwaveuploader/carrierwave/blob/master/README.md#recreating-versions
