### PR TITLE
Fix (suggestion?) : StoreAssetWorker throws an exception when using remove_column! method from carrierwave then upload a file again

### DIFF
--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -84,6 +84,10 @@ module CarrierWave
               super if process_#{column}_upload
             end
 
+            def remove_#{column}!
+              #{column}_tmp = nil
+              super
+            end
           RUBY
 
           _define_shared_backgrounder_methods(mod, column, worker)


### PR DESCRIPTION
This bug (afaik) only occurs when the Store worker is interrupted somewhere during processing 
(i'm processing video  so the processing time is very long).
When this happens, the column_tmp file is never set to nil and the next StoreAssetWorker won't work correctly.
