### PR TITLE
Fix removing files on update

### DIFF
--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -75,6 +75,11 @@ module CarrierWave
           mod = Module.new
           include mod
           mod.class_eval  <<-RUBY, __FILE__, __LINE__ + 1
+            def remove_#{column}=(value)
+              super
+              self.process_#{column}_upload = true
+            end
+
             def write_#{column}_identifier
               super and return if process_#{column}_upload
               self.#{column}_tmp = _mounter(:#{column}).cache_name if _mounter(:#{column}).cache_name


### PR DESCRIPTION
During updating, if the `#remove_<column>` was assigned, then carrierwave_backgrounder would prevent deletion of that photo (that is, it would prevent assigning the column to a blank value).
