### PR TITLE
The option :do_not_delay is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ This must be set before you assign an upload:
 @user.attributes = params[:user]
 ```
 
+You can also bypass backgrounding selectively only for some processors in uploader or
+only for some versions. For that an option :do_not_delay with value true should be used.
+
+```ruby
+# In an uploader
+process :set_metadata, :do_not_delay => true
+
+version :thumb, :do_not_delay => true do
+  # some code
+end
+```
+
 ### Override worker
 To overide the worker in cases where additional methods need to be called or you have app specific requirements, pass the worker class as the
 second argument:

--- a/lib/backgrounder/delay.rb
+++ b/lib/backgrounder/delay.rb
@@ -2,6 +2,102 @@ module CarrierWave
   module Backgrounder
 
     module Delay
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        ##
+        # Adds a processor callback which applies operations as a file is uploaded.
+        # The argument may be the name of any method of the uploader, expressed as a symbol,
+        # or a list of such methods, or a hash where the key is a method and the value is
+        # an array of arguments to call the method with
+        #
+        # === Parameters
+        #
+        # args (*Symbol, Hash{Symbol => Array[]})
+        #
+        # === Examples
+        #
+        #     class MyUploader < CarrierWave::Uploader::Base
+        #
+        #       process :sepiatone, :vignette
+        #       process :scale => [200, 200]
+        #       process :scale => [200, 200], :if => :image?
+        #       process :sepiatone, :if => :image?, :do_not_delay => true
+        #
+        #       def sepiatone
+        #         ...
+        #       end
+        #
+        #       def vignette
+        #         ...
+        #       end
+        #
+        #       def scale(height, width)
+        #         ...
+        #       end
+        #
+        #       def image?
+        #         ...
+        #       end
+        #
+        #     end
+        #
+        def process(*args)
+          if !args.first.is_a?(Hash) && args.last.is_a?(Hash)
+            conditions = args.pop
+            args.map!{ |arg| {arg => []}.merge(conditions) }
+          end
+
+          args.each do |arg|
+            if arg.is_a?(Hash)
+              condition = arg.delete(:if)
+              do_not_delay = arg.delete :do_not_delay
+              do_not_delay = version_options.key?(:do_not_delay) ?
+                             version_options[:do_not_delay] : do_not_delay
+              arg.each do |method, args|
+                self.processors += [[method, args, condition, do_not_delay]]
+              end
+            else
+              self.processors += [[arg, [], nil]]
+            end
+          end
+        end
+
+        ##
+        # Returns the uppermost Uploader
+        #
+        def root_uploader
+          superclass == CarrierWave::Uploader::Base ? self : superclass
+        end
+
+        ##
+        # Returns the options passed to the :version clause in the uploader.
+        # Here is used the fact that at the moment the method is called
+        # the latest version is the current one.
+        #
+        def version_options
+          version = root_uploader.versions.to_a.last
+          version.nil? ? {} : version.last[:options]
+        end
+
+        ##
+        # If the uploader belongs to a version, returns its option :do_not_delay.
+        # For the root uploader returns true if any clause :process has this option.
+        #
+        def do_not_delay?
+          k, hash = root_uploader.versions.to_a.detect do |k, hash|
+            hash[:uploader] == self
+          end
+          hash[:options][:do_not_delay]
+        rescue
+          processors.any? do |method, args, condition, do_not_delay|
+            do_not_delay
+          end
+        end
+      end # ClassMethods
+
       def cache_versions!(new_file)
         super if proceed_with_versioning?
       end
@@ -10,14 +106,25 @@ module CarrierWave
         super if proceed_with_versioning?
       end
 
+      ##
+      # Apply all process callbacks added through CarrierWave.process
+      #
       def process!(new_file=nil)
-        super if proceed_with_versioning?
+        if enable_processing
+          self.class.processors.each do |method, args, condition, do_not_delay|
+            next unless proceed_with_versioning?(do_not_delay)
+            if condition
+              next if !(condition.respond_to?(:call) ? condition.call(self, :args => args, :method => method, :file => new_file) : self.send(condition, new_file))
+            end
+            self.send(method, *args)
+          end
+        end
       end
 
       private
 
-      def proceed_with_versioning?
-        !model.respond_to?(:"process_#{mounted_as}_upload") || model.send(:"process_#{mounted_as}_upload")
+      def proceed_with_versioning?(do_not_delay = self.class.do_not_delay?)
+        !model.respond_to?(:"process_#{mounted_as}_upload") || model.send(:"process_#{mounted_as}_upload") ^ do_not_delay
       end
     end # Delay
 

--- a/lib/backgrounder/delay.rb
+++ b/lib/backgrounder/delay.rb
@@ -66,14 +66,14 @@ module CarrierWave
         end
 
         ##
-        # Returns the parent Uploader unless self is topmost
+        # Returns the uppermost Uploader
         #
         def parent_uploader
           superclass == CarrierWave::Uploader::Base ? self : superclass
         end
 
         ##
-        # Returns the options passed to the :version clause in the uploader.
+        # Returns the options passed to the :version clause in the uploader
         # Here is used the fact that at the moment the method is called
         # the latest version is the current one.
         #

--- a/lib/backgrounder/orm/activemodel.rb
+++ b/lib/backgrounder/orm/activemodel.rb
@@ -27,7 +27,8 @@ module CarrierWave
         end
 
         def _supported_callback
-          if respond_to?(:after_commit) and not Rails.env.test?
+          test = Rails.env.test? rescue ENV['RAILS_ENV'] == 'test'
+          if respond_to?(:after_commit) and not test
             :after_commit
           else
             :after_save

--- a/lib/backgrounder/orm/activemodel.rb
+++ b/lib/backgrounder/orm/activemodel.rb
@@ -27,7 +27,11 @@ module CarrierWave
         end
 
         def _supported_callback
-          respond_to?(:after_commit) ? :after_commit : :after_save
+          if respond_to?(:after_commit) and not Rails.env.test?
+            :after_commit
+          else
+            :after_save
+          end
         end
       end # ActiveModel
 


### PR DESCRIPTION
The option :do_not_delay is created that can be added to clauses :process and :version in an uploader. It is very userfull if some quick processing should be done before saving the model and/or some important version(s) should be created.
