### PR TITLE
Check if record is nil before storing it

### DIFF
--- a/lib/backgrounder/workers/store_asset.rb
+++ b/lib/backgrounder/workers/store_asset.rb
@@ -8,7 +8,7 @@ module CarrierWave
       def perform(*args)
         record = super(*args)
 
-        if record.send(:"#{column}_tmp")
+        if record && record.send(:"#{column}_tmp")
           store_directories(record)
           record.send :"process_#{column}_upload=", true
           record.send :"#{column}_tmp=", nil


### PR DESCRIPTION
When the record doesn't exist anymore, the store_asset worker fails with the exception

```
undefined method `#{column}_tmp' for nil:NilClass
```

It needs to check if the record is nil before calling `#{column}_tmp` to fail silently as it does in process_asset.
