### PR TITLE
set processing to false instead of nil

### DIFF
--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -10,7 +10,7 @@ module CarrierWave
         if record
           record.send(:"process_#{column}_upload=", true)
           if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
-            record.update_attribute :"#{column}_processing", nil
+            record.update_attribute :"#{column}_processing", false
           end
         end
       end

--- a/lib/backgrounder/workers/store_asset.rb
+++ b/lib/backgrounder/workers/store_asset.rb
@@ -12,7 +12,7 @@ module CarrierWave
           store_directories(record)
           record.send :"process_#{column}_upload=", true
           record.send :"#{column}_tmp=", nil
-          record.send :"#{column}_processing=", nil if record.respond_to?(:"#{column}_processing")
+          record.send :"#{column}_processing=", false if record.respond_to?(:"#{column}_processing")
           File.open(cache_path) { |f| record.send :"#{column}=", f }
           if record.save!
             FileUtils.rm_r(tmp_directory, :force => true)

--- a/spec/backgrounder/workers/process_asset_spec.rb
+++ b/spec/backgrounder/workers/process_asset_spec.rb
@@ -29,7 +29,7 @@ describe CarrierWave::Workers::ProcessAsset do
 
     it 'processes versions with image_processing column' do
       user.expects(:respond_to?).with(:image_processing).once.returns(true)
-      user.expects(:update_attribute).with(:image_processing, nil).once
+      user.expects(:update_attribute).with(:image_processing, false).once
       worker.perform
     end
 


### PR DESCRIPTION
It seems to me like processing should be set to `false` rather than `nil` to allow for `:null => false` columns.
