### PR TITLE
set to false already existing rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Optionally you can add a column to the database which will be set to `true` when
 the background processing is start and to `false` when the background processing is complete.
 
 ```ruby
-add_column :users, :avatar_processing, :boolean, null: false
+add_column :users, :avatar_processing, :boolean, null: false, default: false
 ```
 
 ### To use store_in_background


### PR DESCRIPTION
If there are existing rows the migration can't be made because null isn't allowed setting default to false allows migrations to run by setting false instead of null
