### PR TITLE
Use `enqueue_#{column}_background_job?` to process in foreground

### DIFF
--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -75,18 +75,16 @@ module CarrierWave
           mod = Module.new
           include mod
           mod.class_eval  <<-RUBY, __FILE__, __LINE__ + 1
-            def remove_#{column}=(value)
-              super
-              self.process_#{column}_upload = true
-            end
-
             def write_#{column}_identifier
-              super and return if process_#{column}_upload
-              self.#{column}_tmp = _mounter(:#{column}).cache_name if _mounter(:#{column}).cache_name
+              if enqueue_#{column}_background_job?
+                self.#{column}_tmp = _mounter(:#{column}).cache_name if _mounter(:#{column}).cache_name
+              else
+                super
+              end
             end
 
             def store_#{column}!
-              super if process_#{column}_upload
+              super unless enqueue_#{column}_background_job?
             end
 
           RUBY


### PR DESCRIPTION
Pull request #169 sets `process_#{column}_upload = true` when `remove_#{column}` is set, even if it is set to false.
In this case, the file will not be processed in a background process.

In this pull request, I use `enqueue_#{column}_background_job?` (which checks if the file is marked for removal) instead of `process_#{column}_upload` to check if it should be a background process or if carrierwave should handle the processing directly.