### PR TITLE
Respect Class Level Process Enabling

### DIFF
--- a/lib/backgrounder/delay.rb
+++ b/lib/backgrounder/delay.rb
@@ -17,7 +17,9 @@ module CarrierWave
       private
 
       def proceed_with_versioning?
-        !model.respond_to?(:"process_#{mounted_as}_upload") || model.send(:"process_#{mounted_as}_upload")
+        !model.respond_to?(:"process_#{mounted_as}_upload") ||
+            model.send(:"process_#{mounted_as}_upload") ||
+            enable_processing
       end
     end # Delay
 


### PR DESCRIPTION
Instance level process labelling is great for unit testing, but it makes
life difficult when using tools like Cucumber. This change uses the
built in CarrierWave class-level support for toggling of processing.
