### PR TITLE
Ensure the background processing job doesn't fail if the file has been removed.

### DIFF
--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -8,9 +8,12 @@ module CarrierWave
         record = super(*args)
 
         if record
-          record.send(:"process_#{column}_upload=", true)
-          if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
-            record.update_attribute :"#{column}_processing", false
+          # Ensure the file is still present, it may have been removed before this background job got to run.
+          if record.send(:"#{column}").file.present?
+            record.send(:"process_#{column}_upload=", true)
+            if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
+              record.update_attribute :"#{column}_processing", false
+            end
           end
         end
       end


### PR DESCRIPTION
In our system we allow the user to remove an image even while it's processing in the background. We have a placeholder image that gets replace as soon as it's been processed. When it comes time for the delayed job to run to process the images the file to process may not exist.

I added some additional checks that skips processing in the case where the file is missing. Exactly the same as when the record can't be found. So in this case the job will exit successfully and be removed from the queue rather than raising an error and staying around as a failed job.

Thank you for this gem, it's working well for us.

If there's anything you'd like cleaned up in this pull request just let me know.