### PR TITLE
Allow priority to be set as a config option for delayed job backend.

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -23,10 +23,16 @@ module CarrierWave
           private
 
           def enqueue_delayed_job(worker, *args)
+            worker_args = {}
             if ::Delayed::Job.new.respond_to?(:queue)
-              ::Delayed::Job.enqueue worker.new(*args), :queue => queue_options[:queue]
+              worker_args[:queue] = queue_options[:queue] if queue_options[:queue]
+              # Only include priority if set
+              worker_args[:priority] = queue_options[:priority] if queue_options[:priority]
+              ::Delayed::Job.enqueue worker.new(*args), worker_args
             else
-              ::Delayed::Job.enqueue worker.new(*args)
+              # Only include priority if set
+              worker_args[:priority] = queue_options[:priority] if queue_options[:priority]
+              ::Delayed::Job.enqueue worker.new(*args), worker_args
               if queue_options[:queue]
                 ::Rails.logger.warn("Queue name given but no queue column exists for Delayed::Job")
               end

--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -26,11 +26,9 @@ module CarrierWave
             worker_args = {}
             if ::Delayed::Job.new.respond_to?(:queue)
               worker_args[:queue] = queue_options[:queue] if queue_options[:queue]
-              # Only include priority if set
               worker_args[:priority] = queue_options[:priority] if queue_options[:priority]
               ::Delayed::Job.enqueue worker.new(*args), worker_args
             else
-              # Only include priority if set
               worker_args[:priority] = queue_options[:priority] if queue_options[:priority]
               ::Delayed::Job.enqueue worker.new(*args), worker_args
               if queue_options[:queue]


### PR DESCRIPTION
I was looking for a way to pass down the priority that the processing job should be scheduled with when using the delayed job backend. I added it as one of the arguments that can be passed for configuration of the backend.

If priority is not set it will, as it did before, schedule the job with the default delayed job priority.