### PR TITLE
Fix for NoMethodError: undefined method `read' for nil:NilClass

### DIFF
--- a/lib/backgrounder/workers/process_asset.rb
+++ b/lib/backgrounder/workers/process_asset.rb
@@ -7,7 +7,7 @@ module CarrierWave
       def perform(*args)
         record = super(*args)
 
-        if record
+        if record && !record.send(:"#{column}").blank?
           record.send(:"process_#{column}_upload=", true)
           if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
             record.update_attribute :"#{column}_processing", false


### PR DESCRIPTION
Hi, thanks for great gem.

I'm using this gem with sucker_punch worker.
When a instance attribute is blank that set with `process_in_background`.

An error happens like below.
`NoMethodError: undefined method 'read' for nil:NilClass`

This error will not happens the attribute is not blank.

So, I think I should not do process background when attribute is blank.

It confirmed in my environment.

My english is OK?
Sorry, my english.
