### PR TITLE
Fix worker when not backgrounded & processing is disabled

### DIFF
--- a/lib/backgrounder/delay.rb
+++ b/lib/backgrounder/delay.rb
@@ -17,8 +17,10 @@ module CarrierWave
       private
 
       def proceed_with_versioning?
-        !model.respond_to?(:"process_#{mounted_as}_upload") && enable_processing ||
-          !!(model.send(:"process_#{mounted_as}_upload") && enable_processing)
+        enable_processing && (
+          !model.respond_to?(:"process_#{mounted_as}_upload") ||
+          !!(model.send(:"process_#{mounted_as}_upload"))
+        )
       end
     end # Delay
 


### PR DESCRIPTION
In cases where `enable_processing` is false and the model does not call `process_in_background`,
the logic before would try and call `process_#{mounted_as}_upload` on the model anyway, which
results in a NoMethodError.