### PR TITLE
Any cache_name

### DIFF
--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -82,7 +82,7 @@ module CarrierWave
 
             def write_#{column}_identifier
               super and return if process_#{column}_upload
-              self.#{column}_tmp = _mounter(:#{column}).cache_name if _mounter(:#{column}).cache_name
+              self.#{column}_tmp = #{column}_cache if #{column}_cache
             end
 
             def store_#{column}!

--- a/lib/backgrounder/orm/data_mapper.rb
+++ b/lib/backgrounder/orm/data_mapper.rb
@@ -26,7 +26,7 @@ module CarrierWave
 
             def write_#{column}_identifier
               super and return if process_#{column}_upload
-              self.#{column}_tmp = _mounter(:#{column}).cache_name
+              self.#{column}_tmp = #{column}_cache if #{column}_cache
             end
           RUBY
         end

--- a/lib/backgrounder/orm/data_mapper.rb
+++ b/lib/backgrounder/orm/data_mapper.rb
@@ -23,11 +23,6 @@ module CarrierWave
             def set_#{column}_changed
               @#{column}_changed = attribute_dirty?(:#{column})
             end
-
-            def write_#{column}_identifier
-              super and return if process_#{column}_upload
-              self.#{column}_tmp = #{column}_cache if #{column}_cache
-            end
           RUBY
         end
 


### PR DESCRIPTION
In the new carrierwave we don't have `cache_name` method at all.
Instead we need use `cache_names` if it's master branch.
I did universal helper for this case.
