### PR TITLE
Fix to ProcessAssetMixin

### DIFF
--- a/lib/backgrounder/workers/process_asset_mixin.rb
+++ b/lib/backgrounder/workers/process_asset_mixin.rb
@@ -14,8 +14,11 @@ module CarrierWave
 
         if record && record.send(:"#{column}").present?
           record.send(:"process_#{column}_upload=", true)
-          if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
+          result = record.send(:"#{column}").recreate_versions!
+          if result && record.respond_to?(:"#{column}_processing")
             record.update_attribute :"#{column}_processing", false
+          elsif result
+            record.save
           end
         else
           when_not_ready


### PR DESCRIPTION
Fix to ProcessAssetMixin upon condition that the model does not have a _processing column.  The model still needs to be saved, or it will remain pointing to the old file id.
