### PR TITLE
match with carrierwave's mime-types gem version

### DIFF
--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", ["~> 0.5"]
-  s.add_dependency "mime-types", ["~> 2.3"]
+  s.add_dependency "mime-types", [">= 1.16"]
 
   s.add_development_dependency "rspec", ["~> 3.1.0"]
   s.add_development_dependency "rake"


### PR DESCRIPTION
Carrierwave specifies mime-types as a less restrictive version. https://github.com/carrierwaveuploader/carrierwave/blob/master/carrierwave.gemspec#L26
