### PR TITLE
Adds hook for when record/document not found

### DIFF
--- a/lib/backgrounder/workers/base.rb
+++ b/lib/backgrounder/workers/base.rb
@@ -14,6 +14,7 @@ module CarrierWave
         set_args(*args) if args.present?
         self.record = constantized_resource.find id
       rescue *not_found_errors
+        when_not_found
       end
 
       private
@@ -31,6 +32,9 @@ module CarrierWave
 
       def constantized_resource
         klass.is_a?(String) ? klass.constantize : klass
+      end
+
+      def when_not_found
       end
 
       def when_not_ready


### PR DESCRIPTION
Attempts to resolve #244 by allowing subclassed jobs to implement `when_not_found` in which you can then `raise`.
