### PR TITLE
Fix sidekiq_options-related bug

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -47,7 +47,9 @@ module CarrierWave
           end
 
           def enqueue_sidekiq(worker, *args)
-            override_queue_name = worker.sidekiq_options['queue'] == 'default' || worker.sidekiq_options['queue'].nil?
+            override_queue_name =
+              worker.get_sidekiq_options['queue'] == 'default' \
+                || worker.get_sidekiq_options['queue'].nil?
             args = sidekiq_queue_options(override_queue_name, 'class' => worker, 'args' => args)
             worker.client_push(args)
           end

--- a/spec/support/backend_constants.rb
+++ b/spec/support/backend_constants.rb
@@ -33,8 +33,15 @@ module Sidekiq
     end
 
     module ClassMethods
+      # Sidekiq::Worker#sidekiq_options returns nil instead of the options hash
+      # since 7e094567a585578fad0bfd0c8669efb46643f853
       def sidekiq_options(opts = {})
-        opts
+        @opts = opts
+        nil
+      end
+
+      def get_sidekiq_options
+        @opts || {}
       end
 
       def client_push(item)


### PR DESCRIPTION
Fix a bug that `Sidekiq::Worker#sidekiq_options` is expected to returns the options hash but returns `nil` instead (since https://github.com/mperham/sidekiq/commit/7e094567a585578fad0bfd0c8669efb46643f853#diff-d5f274cbf1e35b319e9813606c766ee8)