### PR TITLE
Remove unused dependency "mime-types" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.gem
 .bundle
-Gemfile.lock
 pkg/*
 vendor/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+PATH
+  remote: .
+  specs:
+    carrierwave_backgrounder (0.4.2)
+      carrierwave (~> 0.5)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    carrierwave (0.11.2)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
+      mimemagic (>= 0.3.0)
+    concurrent-ruby (1.0.2)
+    diff-lcs (1.2.5)
+    i18n (0.7.0)
+    json (2.0.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mimemagic (0.3.2)
+    minitest (5.9.1)
+    rake (11.3.0)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  carrierwave_backgrounder!
+  rake
+  rspec (~> 3.1.0)
+
+BUNDLED WITH
+   1.13.6

--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", ["~> 0.5"]
-  s.add_dependency "mime-types", ["~> 2.3"]
 
   s.add_development_dependency "rspec", ["~> 3.1.0"]
   s.add_development_dependency "rake"


### PR DESCRIPTION
`mime-types` doesn't seem to be used so remove it from the gemspec.

The only possible reason that I see for it to be specified is to lock its version for subdependencies, was it that?

And version `Gemfile.lock` to ensure tests are run in consistent environments.