### PR TITLE
Support carrierwave 1.0 and therefore Rails 5

### DIFF
--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", ["~> 0.5"]
+  s.add_dependency "carrierwave", ["~> 1.0"]
   s.add_dependency "mime-types", ["~> 2.3"]
 
   s.add_development_dependency "rspec", ["~> 3.1.0"]


### PR DESCRIPTION
When used in tandem with carrierwave 1.0 which is the version they told you to use with rails 5, carrierwave-background ends up resolving to version 0.0.2.

In this version `CarrierWave::Backgrounder.configure` is not defined so you get an undefined method error. Updating the dependencies to support carrierwave 1.0 allows you to install latest version and keep the compatibility.