### PR TITLE
Upgrade to Carrierwave 1.0.0

### DIFF
--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", ["~> 0.5"]
-  s.add_dependency "mime-types", ["~> 2.3"]
+  s.add_dependency "carrierwave", [">= 0.5", "< 2.0"]
+  s.add_dependency "mime-types", ["~> 3.1"]
 
-  s.add_development_dependency "rspec", ["~> 3.1.0"]
+  s.add_development_dependency "rspec", ["~> 3.5.0"]
   s.add_development_dependency "rake"
 end

--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.5", "< 2.0"]
-  s.add_dependency "mime-types", ["~> 3.1"]
+  s.add_dependency "mime-types", ["~> 2.99"]
 
   s.add_development_dependency "rspec", ["~> 3.5.0"]
   s.add_development_dependency "rake"


### PR DESCRIPTION
```ruby
/Users/liujun/.rbenv/versions/2.4.0/bin/ruby -I/Users/liujun/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-support-3.5.0/lib:/Users/liujun/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib /Users/liujun/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*/\*_spec.rb -c -f progress -r ./spec/spec_helper.rb
............................................................

Finished in 0.0703 seconds (files took 0.49761 seconds to load)
60 examples, 0 failures
```