### PR TITLE
Remove unused dependency "mime-types"

### DIFF
--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.5", "< 2.0"]
-  s.add_dependency "mime-types", ["~> 2.99"]
 
   s.add_development_dependency "rspec", ["~> 3.5.0"]
   s.add_development_dependency "rake"


### PR DESCRIPTION
`mime-types` is not referenced in the code, making it unused.

Was originally introduced through https://github.com/eventfuel/carrierwave_backgrounder/pull/4.

Have cherry-picked from #251, which most likely was closed due to build failure. Without the lock that also was introduced in that PR, everything seems to go as expected - so Travis is happy :wink: