### PR TITLE
Update `mime-types` version

### DIFF
--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.5", "< 2.0"]
-  s.add_dependency "mime-types", ["~> 2.99"]
+  s.add_dependency "mime-types", ["~> 3.0"]
 
   s.add_development_dependency "rspec", ["~> 3.5.0"]
   s.add_development_dependency "rake"


### PR DESCRIPTION
Current `mime-types` version is `3.1`.
https://rubygems.org/gems/mime-types

Now, this gem is depend on `"mime-types", ["~> 2.99"]`.
Therefore, `mime-types` can't get upgrade.
I will update this.

Or remove it? #264 