### PR TITLE
Add note for Sidekiq queues configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ CarrierWave::Backgrounder.configure do |c|
 end
 ```
 
+**IMPORTANT FOR SIDEKIQ BACKEND** - Custom queue should be defined inside the Sidekiq configuration otherwise jobs won't be processed:
+
+```yml
+:queues:
+  - [awesome_queue, 1]
+  - default
+```
+
 In your CarrierWave uploader file:
 
 ```ruby


### PR DESCRIPTION
I have tried to use carrierwave_backgrounder with `process_in_background` I was confused why queued jobs weren't processed and spend a while to figure out, decided to help dev who would be use `process_in_background` to reach their goal. There was a question on stackoverflow.com which doesn't give an answer therefore I am not alone who had the same problems. https://stackoverflow.com/questions/43747320/how-to-upload-files-in-the-background-using-rails-carrierwave/43750232#43750232