### PR TITLE
Fix no 'perfom_later' method for enqueue_active_job

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -23,7 +23,7 @@ module CarrierWave
           private
 
           def enqueue_active_job(worker, *args)
-            worker.perform_later(*args.map(&:to_s))
+            worker.perform(*args.map(&:to_s))
           end
 
           def enqueue_delayed_job(worker, *args)

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -34,8 +34,8 @@ module CarrierWave::Backgrounder
       context 'active_job' do
         let(:args) { ['FakeClass', 1, :image] }
 
-        it 'invokes perform_later with string arguments' do
-          expect(MockWorker).to receive(:perform_later).with('FakeClass', '1', 'image')
+        it 'invokes perform with string arguments' do
+          expect(MockWorker).to receive(:perform).with('FakeClass', '1', 'image')
           mock_module.backend :active_job
           mock_module.enqueue_for_backend(MockWorker, *args)
         end


### PR DESCRIPTION
When you try to use Active Job, you get following error: `undefined method `perform_later' for CarrierWave::Workers::ProcessAsset:Class`