### PR TITLE
Destroyed Record Bugfix and Improved Readiness check

### DIFF
--- a/lib/backgrounder/workers/process_asset_mixin.rb
+++ b/lib/backgrounder/workers/process_asset_mixin.rb
@@ -11,8 +11,9 @@ module CarrierWave
 
       def perform(*args)
         record = super(*args)
+        return if record.nil?
 
-        if record && record.send(:"#{column}").present?
+        if record.send(:"#{column}?")
           record.send(:"process_#{column}_upload=", true)
           if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
             record.update_attribute :"#{column}_processing", false

--- a/lib/backgrounder/workers/store_asset_mixin.rb
+++ b/lib/backgrounder/workers/store_asset_mixin.rb
@@ -13,8 +13,9 @@ module CarrierWave
 
       def perform(*args)
         record = super(*args)
+        return if record.nil?
 
-        if record && record.send(:"#{column}_tmp")
+        if record.send(:"#{column}_tmp")
           store_directories(record)
           record.send :"process_#{column}_upload=", true
           record.send :"#{column}_tmp=", nil

--- a/spec/backgrounder/workers/process_asset_spec.rb
+++ b/spec/backgrounder/workers/process_asset_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe CarrierWave::Workers::ProcessAsset do
 
     before do
       allow(user).to receive(:find).with('22').and_return(user).once
-      allow(user).to receive(:image).twice.and_return(image)
+      allow(user).to receive(:image?).once.and_return(true)
+      allow(user).to receive(:image).once.and_return(image)
       allow(user).to receive(:process_image_upload=).with(true).once
       allow(image).to receive(:recreate_versions!).once.and_return(true)
     end
@@ -47,7 +48,8 @@ RSpec.describe CarrierWave::Workers::ProcessAsset do
 
     before do
       allow(admin).to receive(:find).with('23').and_return(admin).once
-      allow(admin).to receive(:avatar).twice.and_return(avatar)
+      allow(admin).to receive(:avatar?).once.and_return(true)
+      allow(admin).to receive(:avatar).once.and_return(avatar)
       allow(admin).to receive(:process_avatar_upload=).with(true).once
       allow(admin).to receive(:respond_to?).with(:avatar_processing).once.and_return(false)
       allow(avatar).to receive(:recreate_versions!).once.and_return(true)


### PR DESCRIPTION
Hello!

I recently came across a bug which is causing my application to produce an insane amount of log entries, plus making it consume a lot of resources.

This issue is caused by a job that is being retried infinitely because of the implementation of the method `when_not_ready` which was overwritten in my project, something like this:

```
class ProcessAssetJob < ApplicationJob
  include ::CarrierWave::Workers::ProcessAssetMixin

  queue_as :high

  def when_not_ready
    retry_job
  end
end
```

Since `when_not_ready` was overwritten to retry the job, and this method was being called from [this line](https://github.com/lardawge/carrierwave_backgrounder/blob/38b381faaace6c75f7310ea726dcd1be2604d3fb/lib/backgrounder/workers/process_asset_mixin.rb#L21), because the record in question was deleted from the db, it was infinitely retrying this job.

This PR solves that issue by adding a guard clause right before checking if the record is ready to be processed, this way if the record does not exist, it won't retry the job and we can safely call `retry_job` from the `when_not_ready` method.

Another issue I noticed was this one:

```
if record.send(:"#{column}").present?
```

Since the `column` attribute is defined inside the models like this (i.e with an `image`):

```
mount_uploader :image, ImageUploader
```

if we call `record.image` it will never be `falsey`, since it will return an instance of the `ImageUploader`. So to properly check if there is an image, we can do `record.image?` which will properly return `true` or `false` if there is an image available.

