### PR TITLE
fog 2.1.0, fog-google 1.9.1 support

### DIFF
--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.5", "< 2.0"]
-  s.add_dependency "mime-types", ["~> 2.99"]
+  s.add_dependency "mime-types", ["~> 3.00"]
 
   s.add_development_dependency "rspec", ["~> 3.5.0"]
   s.add_development_dependency "rake"


### PR DESCRIPTION
Change mime type to ~> 3.0.0 from 2.9.9

I have got carrierwave_backgrounder working with fog 2.1.0