### PR TITLE
Add missing `require 'fileutils'`

### DIFF
--- a/lib/backgrounder/workers/store_asset_mixin.rb
+++ b/lib/backgrounder/workers/store_asset_mixin.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require 'fileutils'
+
 module CarrierWave
   module Workers
 


### PR DESCRIPTION
FileUtils is not loaded automatically.
We should require it before use.

This PR fixes broken CI like the following:
```
Failures:
  1) CarrierWave::Workers::StoreAsset#perform removes tmp directory on success
     Failure/Error: expect(FileUtils).to receive(:rm_r).with(fixtures_path, :force => true).once
     
     NameError:
       uninitialized constant FileUtils
       Did you mean?  FileTest
     # ./spec/backgrounder/workers/store_asset_spec.rb:35:in `block (3 levels) in <top (required)>'
  2) CarrierWave::Workers::StoreAsset#perform does not remove the tmp directory if save! fails
     Failure/Error: expect(FileUtils).to receive(:rm_r).never
     
     NameError:
       uninitialized constant FileUtils
       Did you mean?  FileTest
     # ./spec/backgrounder/workers/store_asset_spec.rb:41:in `block (3 levels) in <top (required)>'
```
https://travis-ci.org/github/lardawge/carrierwave_backgrounder/jobs/749278439