### PR TITLE
WIP: add support for selective processing

### DIFF
--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.5", "< 2.2"]
+  s.add_dependency "activesupport", ">= 4.0.0"
 
   s.add_development_dependency "rspec", ["~> 3.10.0"]
   s.add_development_dependency "rake"

--- a/lib/backgrounder/delay.rb
+++ b/lib/backgrounder/delay.rb
@@ -1,7 +1,16 @@
+require 'active_support/concern'
+
 module CarrierWave
   module Backgrounder
 
     module Delay
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :selective_processing, instance_writer: false
+        self.selective_processing = false
+      end
+
       def cache_versions!(new_file)
         super if proceed_with_versioning?
       end
@@ -14,10 +23,26 @@ module CarrierWave
         super if proceed_with_versioning?
       end
 
+      def processing_delayed?(img = nil)
+        model.respond_to?(:"processing_#{mounted_as}_delayed") &&
+          model.send(:"processing_#{mounted_as}_delayed")
+      end
+
+      def processing_immediate?(img = nil)
+        !processing_delayed?(img)
+      end
+
+      module ClassMethods
+        def selective_processing!
+          self.selective_processing = true
+        end
+      end # ClassMethods
+
       private
 
       def proceed_with_versioning?
-        !model.respond_to?(:"process_#{mounted_as}_upload") && enable_processing ||
+        self.class.selective_processing ||
+          !model.respond_to?(:"process_#{mounted_as}_upload") && enable_processing ||
           !!(model.send(:"process_#{mounted_as}_upload") && enable_processing)
       end
     end # Delay

--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -40,6 +40,7 @@ module CarrierWave
         #
         def process_in_background(column, worker=::CarrierWave::Workers::ProcessAsset)
           attr_accessor :"process_#{column}_upload"
+          attr_accessor :"processing_#{column}_delayed"
 
           mod = Module.new
           include mod

--- a/lib/backgrounder/workers/process_asset_mixin.rb
+++ b/lib/backgrounder/workers/process_asset_mixin.rb
@@ -13,6 +13,7 @@ module CarrierWave
         record = super(*args)
 
         if record && record.send(:"#{column}").present?
+          record.send(:"processing_#{column}_delayed=", true)
           record.send(:"process_#{column}_upload=", true)
           if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
             record.update_attribute :"#{column}_processing", false

--- a/spec/backgrounder/workers/process_asset_spec.rb
+++ b/spec/backgrounder/workers/process_asset_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe CarrierWave::Workers::ProcessAsset do
       allow(user).to receive(:find).with('22').and_return(user).once
       allow(user).to receive(:image).twice.and_return(image)
       allow(user).to receive(:process_image_upload=).with(true).once
+      allow(user).to receive(:processing_image_delayed=).with(true).once
       allow(image).to receive(:recreate_versions!).once.and_return(true)
     end
 
@@ -49,6 +50,7 @@ RSpec.describe CarrierWave::Workers::ProcessAsset do
       allow(admin).to receive(:find).with('23').and_return(admin).once
       allow(admin).to receive(:avatar).twice.and_return(avatar)
       allow(admin).to receive(:process_avatar_upload=).with(true).once
+      allow(admin).to receive(:processing_avatar_delayed=).with(true).once
       allow(admin).to receive(:respond_to?).with(:avatar_processing).once.and_return(false)
       allow(avatar).to receive(:recreate_versions!).once.and_return(true)
 

--- a/spec/backgrounder/workers/store_asset_spec.rb
+++ b/spec/backgrounder/workers/store_asset_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'spec_helper'
 require 'backgrounder/workers/store_asset'
+require 'fileutils'
 
 RSpec.describe CarrierWave::Workers::StoreAsset do
   let(:fixtures_path) { File.expand_path('../fixtures/images', __FILE__) }


### PR DESCRIPTION
A very quick implementation, but it seems to work as it should. 

This is useful when you have a lot of different versions that need to be created, but still want to show a thumbnail, or any other quick representation of the uploaded file.

In any upload that you want to process versions selectively you call `selective_processing!` after including `CarrierWave::Backgrounder::Delay`.

Then for each version you want to process in the background you add `if: :processing_delayed?`, and for the ones you want to process immediately you add `if: :processing_immediate?`.
You could omit the `if: :processing_immediate?`, but then the version would be created twice.

```rb
class ImageUploader < CarrierWave::Uploader::Base
  include CarrierWave::Backgrounder::Delay

  selective_processing!

  version :large, if: :processing_delayed? do
    process resize_to_limit: [1000, nil]
  end

  version :thumbnail, if: :processing_immediate? do
    process resize_to_fill: [200, 200]
  end
end
```

Probably needs some tests as well.

Related:  #30