### PR TITLE
Update carrierwave dependency

### DIFF
--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", [">= 0.5", "< 2.2"]
+  s.add_dependency "carrierwave", [">= 0.5", "< 2.3"]
 
   s.add_development_dependency "rspec", ["~> 3.10.0"]
   s.add_development_dependency "rake"


### PR DESCRIPTION
Update carrierwave dependency.
This is required to update carrierwave to the latest version.