### PR TITLE
Correct Usage of process_in_background in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Each method, #store_in_background and #process_in_background has there own worke
 
 class User < ActiveRecord::Base
   mount_uploader :avatar, AvatarUploader
-  process_in_background, :avatar, MyParanoidWorker
+  process_in_background :avatar, MyParanoidWorker
 end
 
 class MyParanoidWorker < ::CarrierWave::Workers::ProcessAsset
@@ -180,7 +180,7 @@ end
 
 class User < ActiveRecord::Base
   mount_uploader :avatar, AvatarUploader
-  process_in_background, :avatar, MyActiveJobWorker
+  process_in_background :avatar, MyActiveJobWorker
 end
 
 class MyActiveJobWorker < ::CarrierWave::Workers::ActiveJob::StoreAsset


### PR DESCRIPTION
### Overview
This PR corrects the usage of the `process_in_background` method in the README.
The previous version had an extraneous comma, which might have caused confusion for users trying to implement the example code.

### Changes
- Removed commas from the `process_in_background` method calls in two places.