### PR TITLE
fix symbol access, instead of string key

### DIFF
--- a/lib/carrierwave_backgrounder.rb
+++ b/lib/carrierwave_backgrounder.rb
@@ -17,13 +17,13 @@ module CarrierWave
 
       case backend
       when :active_job
-        @worker_klass = "CarrierWave::Workers::ActiveJob"
+        @worker_klass = 'CarrierWave::Workers::ActiveJob'
 
         require 'active_job'
         require 'backgrounder/workers/active_job/process_asset'
         require 'backgrounder/workers/active_job/store_asset'
 
-        queue_name = queue_options['queue'] || 'carrierwave'
+        queue_name = queue_options[:queue] || 'carrierwave'
 
         ::CarrierWave::Workers::ActiveJob::ProcessAsset.class_eval do
           queue_as queue_name
@@ -32,7 +32,7 @@ module CarrierWave
           queue_as queue_name
         end
       when :sidekiq
-        @worker_klass = "CarrierWave::Workers"
+        @worker_klass = 'CarrierWave::Workers'
 
         require 'sidekiq'
         ::CarrierWave::Workers::ProcessAsset.class_eval do


### PR DESCRIPTION
There is a minor bug in the code that allows you to configure the queue name. Currently, the keys are stored as symbols instead of strings. While this may seem like a small issue, it has a significant impact on the functionality of the application. This helps to configure the queue name.