### PR TITLE
Fix nil pointer issue

### DIFF
--- a/lib/backgrounder/workers/process_asset_mixin.rb
+++ b/lib/backgrounder/workers/process_asset_mixin.rb
@@ -11,10 +11,12 @@ module CarrierWave
 
       def perform(*args)
         record = super(*args)
+        return unless record
+
         record.send(:"process_#{column}_upload=", true)
         asset = record.send(:"#{column}")
 
-        return unless record && asset_present?(asset)
+        return unless asset_present?(asset)
 
         recreate_asset_versions!(asset)
 

--- a/spec/integrations/process_in_background_spec.rb
+++ b/spec/integrations/process_in_background_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe '::process_in_background', clear_images: true do
     end
   end
 
+  it 'handles ActiveRecord::RecordNotFound' do
+    worker = CarrierWave::Workers::ProcessAsset.new(Admin, '22', :image)
+    worker.perform
+  end
+
   context 'when processing the worker' do
     before do
       admin.update(avatar: load_file('test-1.jpg'))


### PR DESCRIPTION
Since version 1, when no record is found during processing, "process_#{column}_upload=" is called on it anyway, causing a nil pointer exception. In previous versions the record was just ignored. This restores that behaviour.