### PR TITLE
Backport Active Job

### DIFF
--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -2,7 +2,6 @@ module CarrierWave
   module Backgrounder
     module Support
       module Backends
-
         def self.included(base)
           base.extend ClassMethods
         end
@@ -10,14 +9,15 @@ module CarrierWave
         module ClassMethods
           attr_reader :queue_options
 
-          def backend(queue_name=nil, args={})
+          def backend(queue_name = nil, args = {})
             return @backend if @backend
+
             @queue_options = args
             @backend = queue_name
           end
 
           def enqueue_for_backend(worker, class_name, subject_id, mounted_as)
-            self.send :"enqueue_#{backend}", worker, class_name, subject_id, mounted_as
+            send :"enqueue_#{backend}", worker, class_name, subject_id, mounted_as
           end
 
           private
@@ -36,7 +36,7 @@ module CarrierWave
               worker_args[:priority] = queue_options[:priority] if queue_options[:priority]
               ::Delayed::Job.enqueue worker.new(*args), worker_args
               if queue_options[:queue]
-                ::Rails.logger.warn("Queue name given but no queue column exists for Delayed::Job")
+                ::Rails.logger.warn('Queue name given but no queue column exists for Delayed::Job')
               end
             end
           end
@@ -53,11 +53,12 @@ module CarrierWave
           end
 
           def enqueue_girl_friday(worker, *args)
-            @girl_friday_queue ||= GirlFriday::WorkQueue.new(queue_options.delete(:queue) || :carrierwave, queue_options) do |msg|
+            @girl_friday_queue ||= GirlFriday::WorkQueue.new(queue_options.delete(:queue) || :carrierwave,
+                                                             queue_options) do |msg|
               worker = msg[:worker]
               worker.perform
             end
-            @girl_friday_queue << { :worker => worker.new(*args) }
+            @girl_friday_queue << { worker: worker.new(*args) }
           end
 
           def enqueue_sucker_punch(worker, *args)
@@ -79,9 +80,7 @@ module CarrierWave
           end
 
           def sidekiq_queue_options(override_queue_name, args)
-            if override_queue_name && queue_options[:queue]
-              args['queue'] = queue_options[:queue]
-            end
+            args['queue'] = queue_options[:queue] if override_queue_name && queue_options[:queue]
             args['retry'] = queue_options[:retry] unless queue_options[:retry].nil?
             args['timeout'] = queue_options[:timeout] if queue_options[:timeout]
             args['backtrace'] = queue_options[:backtrace] if queue_options[:backtrace]

--- a/lib/backgrounder/workers/active_job/process_asset.rb
+++ b/lib/backgrounder/workers/active_job/process_asset.rb
@@ -1,0 +1,11 @@
+require 'backgrounder/workers/process_asset_mixin'
+
+module CarrierWave
+  module Workers
+    module ActiveJob
+      class ProcessAsset < ::ActiveJob::Base
+        include CarrierWave::Workers::ProcessAssetMixin
+      end
+    end # ActiveJob
+  end # Workers
+end # Backgrounder

--- a/lib/backgrounder/workers/active_job/store_asset.rb
+++ b/lib/backgrounder/workers/active_job/store_asset.rb
@@ -1,0 +1,11 @@
+require 'backgrounder/workers/store_asset_mixin'
+
+module CarrierWave
+  module Workers
+    module ActiveJob
+      class StoreAsset < ::ActiveJob::Base
+        include CarrierWave::Workers::StoreAssetMixin
+      end
+    end # ActiveJob
+  end # Workers
+end # Backgrounder

--- a/lib/backgrounder/workers/process_asset_mixin.rb
+++ b/lib/backgrounder/workers/process_asset_mixin.rb
@@ -1,7 +1,5 @@
-# encoding: utf-8
 module CarrierWave
   module Workers
-
     module ProcessAssetMixin
       include CarrierWave::Workers::Base
 
@@ -11,18 +9,27 @@ module CarrierWave
 
       def perform(*args)
         record = super(*args)
+        record.send(:"process_#{column}_upload=", true)
+        asset = record.send(:"#{column}")
 
-        if record && record.send(:"#{column}").present?
-          record.send(:"process_#{column}_upload=", true)
-          if record.send(:"#{column}").recreate_versions! && record.respond_to?(:"#{column}_processing")
-            record.update_attribute :"#{column}_processing", false
-          end
-        else
-          when_not_ready
-        end
+        return unless record && asset_present?(asset)
+
+        recreate_asset_versions!(asset)
+
+        return unless record.respond_to?(:"#{column}_processing")
+
+        record.update_attribute :"#{column}_processing", false
       end
 
-    end # ProcessAssetMixin
+      private
 
+      def recreate_asset_versions!(asset)
+        asset.is_a?(Array) ? asset.map(&:recreate_versions!) : asset.recreate_versions!
+      end
+
+      def asset_present?(asset)
+        asset.is_a?(Array) ? asset.present? : asset.file.present?
+      end
+    end # ProcessAssetMixin
   end # Workers
 end # Backgrounder

--- a/lib/carrierwave_backgrounder.rb
+++ b/lib/carrierwave_backgrounder.rb
@@ -1,4 +1,3 @@
-require 'fileutils'
 require 'active_support/core_ext/object'
 require 'backgrounder/support/backends'
 require 'backgrounder/orm/base'
@@ -8,10 +7,31 @@ module CarrierWave
   module Backgrounder
     include Support::Backends
 
+    class << self
+      attr_reader :worker_klass
+    end
+
     def self.configure
       yield self
       case @backend
+      when :active_job
+        @worker_klass = 'CarrierWave::Workers::ActiveJob'
+
+        require 'active_job'
+        require 'backgrounder/workers/active_job/process_asset'
+        require 'backgrounder/workers/active_job/store_asset'
+
+        queue_name = queue_options[:queue] || 'carrierwave'
+
+        ::CarrierWave::Workers::ActiveJob::ProcessAsset.class_eval do
+          queue_as queue_name
+        end
+        ::CarrierWave::Workers::ActiveJob::StoreAsset.class_eval do
+          queue_as queue_name
+        end
       when :sidekiq
+        @worker_klass = 'CarrierWave::Workers'
+
         require 'sidekiq'
         ::CarrierWave::Workers::ProcessAsset.class_eval do
           include ::Sidekiq::Worker
@@ -29,7 +49,6 @@ module CarrierWave
         end
       end
     end
-
   end
 end
 


### PR DESCRIPTION
This commit backports to 0.4.3 the ActiveJob code from 1.0+.

It also modifies the process_asset_mixin to use the newer 1.0+ code in the hopes of fixing whatever issue is preventing jobs from failing silently.