### PR TITLE
Skip deleted record

### DIFF
--- a/lib/backgrounder/workers/process_asset_mixin.rb
+++ b/lib/backgrounder/workers/process_asset_mixin.rb
@@ -11,10 +11,12 @@ module CarrierWave
 
       def perform(*args)
         record = super(*args)
+        return unless record
+
         record.send(:"process_#{column}_upload=", true)
         asset = record.send(:"#{column}")
 
-        return unless record && asset_present?(asset)
+        return unless asset_present?(asset)
 
         recreate_asset_versions!(asset)
 

--- a/spec/integrations/process_in_background_spec.rb
+++ b/spec/integrations/process_in_background_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe '::process_in_background', clear_images: true do
     end
   end
 
+  it 'handles ActiveRecord::RecordNotFound' do
+    worker = CarrierWave::Workers::ProcessAsset.new(Admin, '22', :image)
+    worker.perform
+  end
+
   context 'when processing the worker' do
     before do
       admin.update(avatar: load_file('test-1.jpg'))


### PR DESCRIPTION
Ignore delete records when processing records. This was the old behaviour before version 1, and makes more sense than raising an `undefined method ... for nil` exception that occurs otherwise.